### PR TITLE
Updated version compatability

### DIFF
--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -17,7 +17,7 @@
 		</author>
 	</authors>
 	<releases>
-		<release version="1.1" date="2012-05-29" min="2.3">
+		<release version="1.1" date="2012-05-29" min="2.3" max="2.4.x">
 			- Update for Symphony 2.3 compatibility
 			- Use new `PageManager` functions
 		</release>


### PR DESCRIPTION
Seems to work fine with 2.4 - given further testing I assume this is the correct way to flag it?
